### PR TITLE
added post id as pid on Posts

### DIFF
--- a/Sources/FourChan/FourChan.swift
+++ b/Sources/FourChan/FourChan.swift
@@ -93,7 +93,7 @@ public struct Post: Codable, Hashable {
   public let trip: String?
 
   // Conflicts with Identifiable protocol.
-  // public let id: String?
+  public let pid: String?
   /// Capcode
   public let capcode: String?
 
@@ -188,6 +188,17 @@ public struct Post: Codable, Hashable {
 
 extension Post: Identifiable {
   public var id: Int { return no }
+}
+
+extension Post {
+  enum CodingKeys: String, CodingKey {
+      case pid = "id"
+      case no, resto, sticky, closed, archived, archived_on, now,
+           name, trip, capcode, country, country_name, sub, com,
+           tim, filename, ext, fsize, md5, w, h, tn_w, tn_h, filedeleted,
+           spoiler, custom_spoiler, omitted_posts, omitted_images, time, semantic_url, unique_ips,
+           replies, images, bumplimit, imagelimit, lastReplies, last_modified, tag, since4pass
+  }
 }
 
 /// A FourChan Thread.


### PR DESCRIPTION
Wanted to say thank you so much for making this repo, beautiful code! I had to read it for a while to understand it all because I'm new to swift, but I'm using the comment parser now too. Thanks!

This pr adds the id to Posts (I use biz a lot), I wanted to be able to use this for boards that have the IDs, named it pid for post id. Hopefully that isn't confusing like process id. Anyway, I can change it if you want.